### PR TITLE
Update setup.sh to use `python3` instead of `python` to run the setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cd tools && python setup.py
+cd tools && python3 setup.py


### PR DESCRIPTION
This PR updates setup.sh to use `python3` to run the setup script. This was done for two reasons:

- My knowledge with python is limited, but python3 was the only way I could get the setup script to run locally.
- Keep it consistent as all other places in the documentation use python3.