### PR TITLE
Downloaders logic fixes

### DIFF
--- a/carvekit/utils/download_models.py
+++ b/carvekit/utils/download_models.py
@@ -167,7 +167,7 @@ class HuggingFaceCompatibleDownloader(CachedDownloader, ABC):
             hugging_face_url = f"{self.base_url}/{url['repository']}/resolve/{url['revision']}/{url['filename']}"
 
             try:
-                r = requests.get(hugging_face_url, stream=True)
+                r = requests.get(hugging_face_url, stream=True, timeout=10)
                 if r.status_code < 400:
                     with open(cached_path, "wb") as f:
                         r.raw.decode_content = True


### PR DESCRIPTION
- downloader connect timeout is 10 seconds now.
- logging in downloaders is much more conscious now. Every  HuggingFaceCompatibleDownloader object should provide name property for now to be easily identified in logs, class name(HuggingFaceCompatibleDownloader) will be used otherwise.